### PR TITLE
ARC-64: Clarify README about how to get started on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Get and install [Docker](https://www.docker.com/products/docker).
 
-If you are using Docker on Windows, make sure to [enable shared drives](https://docs.docker.com/docker-for-windows/#shared-drives) in your tray.
+If you are using Docker on Windows, make sure to [enable shared drives](https://docs.docker.com/docker-for-windows/#shared-drives). Check your tray for for the Docker icon, and select settings once you right click it.
 
 In the project root build the containers and start them up:
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 Get and install [Docker](https://www.docker.com/products/docker).
 
+If you are using Docker on Windows, make sure to [enable shared drives](https://docs.docker.com/docker-for-windows/#shared-drives) in your tray.
+
 In the project root build the containers and start them up:
 
     docker-compose up --build
-    
+
 Initialize the database:
 
     docker-compose run website rake db:create db:setup


### PR DESCRIPTION
The problem was that `- volume` doesn't work without enabling shared drive on windows.  On Mac it works out of box.
