### PR TITLE
Use real middleware for handling cross-origin requests (including 'options')

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'active_model_serializers'
 gem 'will_paginate', '~> 3.1.0'
 gem 'will_paginate_mongoid'
 
-gem 'rack-cors', :require => 'rack/cors'
+gem 'rack-cors', require: 'rack/cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'active_model_serializers'
 gem 'will_paginate', '~> 3.1.0'
 gem 'will_paginate_mongoid'
 
+gem 'rack-cors', :require => 'rack/cors'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     powerpack (0.1.1)
     puma (3.6.0)
     rack (2.0.1)
+    rack-cors (0.4.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.0.1)
@@ -198,6 +199,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mongoid (~> 6.0.0)
   puma (~> 3.0)
+  rack-cors
   rails (~> 5.0.0, >= 5.0.0.1)
   rubocop
   sass-rails (~> 5.0)
@@ -215,4 +217,4 @@ RUBY VERSION
    ruby 2.2.5p319
 
 BUNDLED WITH
-   1.13.7
+   1.14.3

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,10 +23,12 @@ module Archivist
     # -- all .rb files in that directory are automatically loaded.
     config.api_only = true
 
-    # TODO: update to be more safe
-    config.action_dispatch.default_headers = {
-      'Access-Control-Allow-Origin' => '*',
-      'Access-Control-Request-Method' => %w(GET POST PUT DELETE OPTIONS).join(',')
-    }
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        #TODO: Update to be more safe
+        origins '*'
+        resource '*', headers: :any, methods: [:get, :post, :put, :delete, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
This should fix the issue where sending the ‘DELETE’ verb would complain about ‘OPTIONS’ not being defined for the endpoint.