### PR TITLE
ARC-120: Display content type for documents

### DIFF
--- a/app/controllers/concerns/public_accessible_controller.rb
+++ b/app/controllers/concerns/public_accessible_controller.rb
@@ -2,7 +2,7 @@ module PublicAccessibleController
   extend ActiveSupport::Concern
 
   def show_all_groups
-    render json: Grouping::Group.all, root: 'groups'
+    render json: Grouping::Group.all
   end
 
   def create_doc(params)

--- a/app/controllers/system/groups_controller.rb
+++ b/app/controllers/system/groups_controller.rb
@@ -6,13 +6,13 @@ class System::GroupsController < ApplicationController
   end
 
   def show
-    render json: group, root: 'group'
+    render json: group
   end
 
   def create
     g = Grouping::Group.new(params.require(:group).permit(:name))
     g.save!
-    render json: g, root: 'group'
+    render json: g
   end
 
   def update

--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -1,6 +1,9 @@
 class DocumentSerializer < ActiveModel::Serializer
   attribute :id
   attribute :description, if: -> { instance_options[:complete] }
+  attribute :content_type, if: -> { instance_options[:complete] } do
+    object.file_storage.content_type
+  end
 
   has_many :tags, if: -> { instance_options[:complete] } do
     object.tag_names

--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -1,11 +1,11 @@
 class DocumentSerializer < ActiveModel::Serializer
   attribute :id
-  attribute :description, if: -> { instance_options[:complete] }
-  attribute :content_type, if: -> { instance_options[:complete] } do
+  attribute :description, if: :complete?
+  attribute :content_type, if: :complete? do
     object.file_storage.content_type
   end
 
-  has_many :tags, if: -> { instance_options[:complete] } do
+  has_many :tags, if: :complete? do
     object.tag_names
   end
 
@@ -14,5 +14,9 @@ class DocumentSerializer < ActiveModel::Serializer
     (generic + others.sort_by(&:name)).inject([]) do |memo, group|
       memo << group.sorted_fields
     end.flatten
+  end
+
+  def complete?
+    !!instance_options[:complete]
   end
 end

--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -17,6 +17,6 @@ class DocumentSerializer < ActiveModel::Serializer
   end
 
   def complete?
-    !!instance_options[:complete]
+    instance_options[:complete]
   end
 end

--- a/app/serializers/grouping/group_serializer.rb
+++ b/app/serializers/grouping/group_serializer.rb
@@ -1,6 +1,6 @@
 class Grouping::GroupSerializer < ActiveModel::Serializer
   type :group
-  
+
   attributes :id, :name
   attribute :can_edit?, key: :can_edit
 

--- a/app/serializers/grouping/group_serializer.rb
+++ b/app/serializers/grouping/group_serializer.rb
@@ -1,4 +1,6 @@
 class Grouping::GroupSerializer < ActiveModel::Serializer
+  type :group
+  
   attributes :id, :name
   attribute :can_edit?, key: :can_edit
 


### PR DESCRIPTION
Now when getting a single document you should see the content type as a property.

I can update this to happen when you get all the documents as well b/c I don’t think you need to have the sidebar open to open a doc.