### PR TITLE
ARC-237: Since we don't allow for nil queries, if the data is nil it won't match

### DIFF
--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -22,7 +22,7 @@ class MetadataField < MongoidBase
 
   def self.data_matches?(query, data, type)
     return false if data.nil?
-    
+
     case type
     when MetadataField::String::TYPE
       !/#{query.downcase}/.match(data.downcase).nil?

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -21,6 +21,8 @@ class MetadataField < MongoidBase
   end
 
   def self.data_matches?(query, data, type)
+    return false if data.nil?
+    
     case type
     when MetadataField::String::TYPE
       !/#{query.downcase}/.match(data.downcase).nil?


### PR DESCRIPTION
Search should now work again if one of the documents has a nil value for field you are searching for.